### PR TITLE
Handles missing instance exception

### DIFF
--- a/lib/elasticsearch/drain.rb
+++ b/lib/elasticsearch/drain.rb
@@ -61,6 +61,7 @@ module Elasticsearch
           'Waiter Expired' + $ERROR_INFO
         end
       end
+      class NodeNotFound < RuntimeError; end
     end
   end
 end

--- a/lib/elasticsearch/drain/autoscaling.rb
+++ b/lib/elasticsearch/drain/autoscaling.rb
@@ -71,7 +71,9 @@ module Elasticsearch
       def instance(ipaddress)
         describe_instances if @instances.nil?
         instances = @instances.clone
-        instances.find { |i| i.private_ip_address == ipaddress }
+        instance = instances.find { |i| i.private_ip_address == ipaddress }
+        fail Errors::NodeNotFound if instance.nil?
+        instance
       end
 
       # Sets the MinSize of an AutoScalingGroup

--- a/test/elasticsearch/drain/test_autoscaling.rb
+++ b/test/elasticsearch/drain/test_autoscaling.rb
@@ -22,6 +22,12 @@ class TestAutoScaling < Minitest::Test
     assert_respond_to @asg.find_instances_in_asg, :each
   end
 
+  def test_missing_instance
+    assert_raises(::Elasticsearch::Drain::Errors::NodeNotFound) do
+      @asg.instance('1.1.1.1')
+    end
+  end
+
   def test_find_instances_matches_instance_pattern
     assert_match /i-[a-z0-9]{8}/, @asg.find_instances_in_asg.first
   end


### PR DESCRIPTION
This commit aims to fix the case where we either don't get a response
back from ec2 or we have a timing issue that is causing nil to be
returned.  If we cannot find the instance by ipaddress we throw and
exception and skip the removal steps.  This is safe because we will
reload the list of instances and try again the next time through the
loop.

This fixes #5