### PR TITLE
Accommodate new api changes

### DIFF
--- a/lib/elasticsearch/drain/cluster.rb
+++ b/lib/elasticsearch/drain/cluster.rb
@@ -12,7 +12,7 @@ module Elasticsearch
       def health(opts = {})
         default_opts = {
           wait_for_status: 'green',
-          timeout: 60
+          timeout: '60s'
         }
         opts = default_opts.merge(opts)
         cluster.health(opts)

--- a/lib/elasticsearch/drain/node.rb
+++ b/lib/elasticsearch/drain/node.rb
@@ -53,21 +53,21 @@ module Elasticsearch
       #
       # @return [String] Elasticsearch node ipaddress
       def ipaddress
-        address(info[1]['http_address']).split(':')[0]
+        info[1]['http_address'].split(':')[0]
       end
 
       # The Elasticsearch node Transport Address
       #
       # @return [String] Elasticsearch node Transport Address
       def transport_address
-        address(info[1]['transport_address'])
+        info[1]['transport_address']
       end
 
       # The Elasticsearch node HTTP Address
       #
       # @return [String] Elasticsearch nodes HTTP Address
       def http_address
-        address(info[1]['http_address'])
+        info[1]['http_address']
       end
 
       # Get size in bytes used for indices for a node
@@ -75,14 +75,6 @@ module Elasticsearch
       # @return [Integer] size in bytes used to store indicies on node
       def bytes_stored
         stats[1]['indices']['store']['size_in_bytes']
-      end
-
-      # Extract ip:port from string passed in
-      #
-      # @param [String] str The address object to parse for the ip:port
-      # @return [String] ip:port pair from the data passed in
-      def address(str)
-        str.match(/.+\[\/(.+)\]/)[1]
       end
 
       def in_recovery?


### PR DESCRIPTION
There have been some upstream changes in the elasticsearch ecosystem (not sure if it's the gem or the 2.0 elasticsearch api) which require some modifications. Issues occurred using elasticsearch-{api,transport} 1.0.17 against a 2.0.0 elasticsearch cluster. 

## 1 - (timeout units) - fixed in 4e26005 
```
/var/lib/gems/2.1.0/gems/elasticsearch-transport-1.0.17/lib/elasticsearch/transport/transport/base.rb:201:in `__raise_transport_error': [400] {"error":{"root_cause":[{"type":"parse_exception","reason":"Failed to parse setting [timeout] with value [60] as a time value: unit is missing or unrecognized"}],"type":"parse_exception","reason":"Failed to parse setting [timeout] with value [60] as a time value: unit is missing or unrecognized"},"status":400} (Elasticsearch::Transport::Transport::Errors::BadRequest)
	from /var/lib/gems/2.1.0/gems/elasticsearch-transport-1.0.17/lib/elasticsearch/transport/transport/base.rb:312:in `perform_request'
	from /var/lib/gems/2.1.0/gems/elasticsearch-transport-1.0.17/lib/elasticsearch/transport/transport/http/faraday.rb:20:in `perform_request'
	from /var/lib/gems/2.1.0/gems/elasticsearch-transport-1.0.17/lib/elasticsearch/transport/client.rb:128:in `perform_request'
	from /var/lib/gems/2.1.0/gems/elasticsearch-api-1.0.17/lib/elasticsearch/api/namespace/common.rb:21:in `perform_request'
	from /var/lib/gems/2.1.0/gems/elasticsearch-api-1.0.17/lib/elasticsearch/api/actions/cluster/health.rb:49:in `health'
	from /var/lib/gems/2.1.0/gems/elasticsearch-drain-0.0.5/lib/elasticsearch/drain/cluster.rb:18:in `health'
	from /var/lib/gems/2.1.0/gems/elasticsearch-drain-0.0.5/lib/elasticsearch/drain/cluster.rb:22:in `healthy?'
	from /var/lib/gems/2.1.0/gems/elasticsearch-drain-0.0.5/lib/elasticsearch/drain/cli.rb:31:in `ensure_cluster_healthy'
	from /var/lib/gems/2.1.0/gems/elasticsearch-drain-0.0.5/lib/elasticsearch/drain/cli.rb:19:in `asg'
	from /var/lib/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /var/lib/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /var/lib/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /var/lib/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from /var/lib/gems/2.1.0/gems/elasticsearch-drain-0.0.5/bin/drain:3:in `<top (required)>'
	from /usr/local/bin/drain:23:in `load'
	from /usr/local/bin/drain:23:in `<main>'
```

## 2 - (ipaddresses no longer need to be modified) - f27eebd 
```
/var/lib/gems/2.1.0/gems/elasticsearch-drain-0.0.5/lib/elasticsearch/drain/node.rb:85:in `address': undefined method `[]' for nil:NilClass (NoMethodError)
	from /var/lib/gems/2.1.0/gems/elasticsearch-drain-0.0.5/lib/elasticsearch/drain/node.rb:56:in `ipaddress'
	from /var/lib/gems/2.1.0/gems/elasticsearch-drain-0.0.5/lib/elasticsearch/drain/nodes.rb:42:in `block in nodes_in_asg'
	from /var/lib/gems/2.1.0/gems/elasticsearch-drain-0.0.5/lib/elasticsearch/drain/nodes.rb:42:in `each'
	from /var/lib/gems/2.1.0/gems/elasticsearch-drain-0.0.5/lib/elasticsearch/drain/nodes.rb:42:in `find_all'
	from /var/lib/gems/2.1.0/gems/elasticsearch-drain-0.0.5/lib/elasticsearch/drain/nodes.rb:42:in `nodes_in_asg'
	from /var/lib/gems/2.1.0/gems/elasticsearch-drain-0.0.5/lib/elasticsearch/drain.rb:55:in `active_nodes_in_asg'
	from /var/lib/gems/2.1.0/gems/elasticsearch-drain-0.0.5/lib/elasticsearch/drain/cli.rb:20:in `asg'
	from /var/lib/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /var/lib/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /var/lib/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /var/lib/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from /var/lib/gems/2.1.0/gems/elasticsearch-drain-0.0.5/bin/drain:3:in `<top (required)>'
	from /usr/local/bin/drain:23:in `load'
	from /usr/local/bin/drain:23:in `<main>'
```