### PR TITLE
Flag running SimpleCov

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,13 +1,16 @@
 require 'vcr'
 require 'ipaddr'
 require 'webmock'
-require 'simplecov'
 require 'minitest/spec'
 require 'minitest/autorun'
 require 'elasticsearch/extensions/test/cluster'
 
 gem 'minitest'
-SimpleCov.start
+
+if ENV['COVERAGE'] || ENV['CI']
+  require 'simplecov'
+  SimpleCov.start
+end
 
 require_relative '../lib/elasticsearch/drain'
 


### PR DESCRIPTION
This commit flags running of SimpleCov so that we can skip it locally
and only run it on CI systems.