### PR TITLE
PD-7679: Allow draining specific nodes

### DIFF
--- a/lib/elasticsearch/drain.rb
+++ b/lib/elasticsearch/drain.rb
@@ -40,7 +40,7 @@ module Elasticsearch
 
     # Convience method to access {Elasticsearch::Drain::Nodes}
     def nodes
-      Nodes.new(client, asg)
+      @nodes ||= Nodes.new(client, asg)
     end
 
     # Convience method to access {Elasticsearch::Drain::Cluster#cluster}

--- a/lib/elasticsearch/drain.rb
+++ b/lib/elasticsearch/drain.rb
@@ -52,7 +52,7 @@ module Elasticsearch
 
     def active_nodes_in_asg
       instances = asg.instances
-      nodes.nodes_in_asg(reload: true, instances: instances)
+      nodes.filter_nodes(instances, true)
     end
 
     module Errors

--- a/lib/elasticsearch/drain/cli.rb
+++ b/lib/elasticsearch/drain/cli.rb
@@ -19,14 +19,16 @@ module Elasticsearch
                                             options[:region])
         ensure_cluster_healthy
         @active_nodes = drainer.active_nodes_in_asg
-        do_exit { say_status 'Complete', 'Nothing to do', :green } if active_nodes.empty?
-        say_status 'Found Nodes', "AutoScalingGroup: #{instances}", :magenta
-        ensure_cluster_healthy
+
         # If a node or nodes are specified, only drain the requested node(s)
         @active_nodes = active_nodes.find_all do |n|
           instance_id = drainer.asg.instance(n.ipaddress).instance_id
           options[:nodes].split(',').include?(instance_id)
         end if options[:nodes]
+
+        do_exit { say_status 'Complete', 'Nothing to do', :green } if active_nodes.empty?
+        say_status 'Found Nodes', "AutoScalingGroup: #{instances}", :magenta
+        ensure_cluster_healthy
         drain_nodes
         remove_nodes
         say_status 'Complete', 'Draining nodes complete!', :green

--- a/lib/elasticsearch/drain/cli.rb
+++ b/lib/elasticsearch/drain/cli.rb
@@ -12,6 +12,7 @@ module Elasticsearch
       option :host, default: 'localhost:9200'
       option :asg, required: true
       option :region, required: true
+      option :nodes
       def asg # rubocop:disable Metrics/MethodLength
         @drainer = Elasticsearch::Drain.new(options[:host],
                                             options[:asg],
@@ -21,6 +22,11 @@ module Elasticsearch
         do_exit { say_status 'Complete', 'Nothing to do', :green } if active_nodes.empty?
         say_status 'Found Nodes', "AutoScalingGroup: #{instances}", :magenta
         ensure_cluster_healthy
+        # If a node or nodes are specified, only drain the requested node(s)
+        @active_nodes = active_nodes.find_all do |n|
+          instance_id = drainer.asg.instance(n.ipaddress).instance_id
+          options[:nodes].split(',').include?(instance_id)
+        end if options[:nodes]
         drain_nodes
         remove_nodes
         say_status 'Complete', 'Draining nodes complete!', :green
@@ -45,8 +51,21 @@ module Elasticsearch
           instances.join(' ')
         end
 
+        def adjusted_min_size
+          min_size = drainer.asg.min_size
+          desired_capacity = drainer.asg.desired_capacity
+          if (desired_capacity - active_nodes.length) >= min_size # Removing the active_nodes won't violate the min_size
+            # Reduce the asg min_size proportionally
+            desired_min_size = (min_size - active_nodes.length) <= 0 ? 0 : (min_size - active_nodes.length)
+          else
+            # Removing the active_nodes will result in the min_size being violated
+            desired_min_size = desired_capacity - active_nodes.length
+          end
+          desired_min_size
+        end
+
         def drain_nodes
-          drainer.asg.min_size = 0
+          drainer.asg.min_size = adjusted_min_size
           nodes_to_drain = active_nodes.map(&:id).join(',')
           say_status 'Drain Nodes', "Draining nodes: #{nodes_to_drain}", :magenta
           drainer.cluster.drain_nodes(nodes_to_drain, '_id')
@@ -55,13 +74,13 @@ module Elasticsearch
         def remove_nodes # rubocop:disable Metrics/MethodLength
           while active_nodes.length > 0
             active_nodes.each do |instance|
-              self.active_nodes = drainer.active_nodes_in_asg
+              instance = drainer.nodes.filter_nodes([instance], true).first
               if instance.bytes_stored > 0
                 say_status 'Drain Status', "Node #{instance.ipaddress} has #{instance.bytes_stored} bytes to move", :blue
                 sleep 2
               else
                 next unless remove_node(instance)
-                self.active_nodes = drainer.active_nodes_in_asg
+                active_nodes.delete_if { |n| n.ipaddress == instance.ipaddress }
                 break if active_nodes.length < 1
                 say_status 'Waiting', 'Sleeping for 1 minute before removing the next node', :green
                 sleep 60

--- a/lib/elasticsearch/drain/nodes.rb
+++ b/lib/elasticsearch/drain/nodes.rb
@@ -26,7 +26,7 @@ module Elasticsearch
       # Get list of nodes in the cluster
       #
       # @return [Array<OpenStruct>] Array of node objects
-      def nodes(reload: false)
+      def nodes(reload = false)
         load if reload
         @info['nodes'].map do |node|
           Drain::Node.new(
@@ -38,8 +38,8 @@ module Elasticsearch
         end
       end
 
-      def nodes_in_asg(reload: false, instances:)
-        nodes(reload: false).find_all { |n| instances.include? n.ipaddress }
+      def filter_nodes(instances, reload = false)
+        nodes(reload).find_all { |n| instances.include? n.ipaddress }
       end
     end
   end


### PR DESCRIPTION
This PR adds a `--nodes` CLI option that allows the user to specify a comma delimited list of instance IDs to drain.