### PR TITLE
Fixes resizing asg min_size

### DIFF
--- a/lib/elasticsearch/drain/autoscaling.rb
+++ b/lib/elasticsearch/drain/autoscaling.rb
@@ -85,7 +85,7 @@ module Elasticsearch
           auto_scaling_group_name: asg,
           min_size: count
         )
-        wait_until(0) do
+        wait_until(count) do
           min_size
         end
       end


### PR DESCRIPTION
This fixes resizing when we are not draining a whole asg.