### PR TITLE
Feature: Decommission number of nodes

### DIFF
--- a/lib/elasticsearch/drain.rb
+++ b/lib/elasticsearch/drain.rb
@@ -38,12 +38,12 @@ module Elasticsearch
       @asg_client ||= AutoScaling.new(@asg_name, @region)
     end
 
-    # Convience method to access {Elasticsearch::Drain::Nodes}
+    # Convenience method to access {Elasticsearch::Drain::Nodes}
     def nodes
       @nodes ||= Nodes.new(client, asg)
     end
 
-    # Convience method to access {Elasticsearch::Drain::Cluster#cluster}
+    # Convenience method to access {Elasticsearch::Drain::Cluster#cluster}
     #
     # @return [Elasticsearch::API::Cluster] Elasticsearch cluster client
     def cluster

--- a/lib/elasticsearch/drain/autoscaling.rb
+++ b/lib/elasticsearch/drain/autoscaling.rb
@@ -19,11 +19,15 @@ module Elasticsearch
       end
 
       def asg_client
-        Aws::AutoScaling::Client.new(region: region)
+        Aws::AutoScaling::Client.new(region: region, credentials: creds)
       end
 
       def ec2_client
-        Aws::EC2::Client.new(region: region)
+        Aws::EC2::Client.new(region: region, credentials: creds)
+      end
+
+      def creds
+        Aws::SharedCredentials.new
       end
 
       def find_instances_in_asg

--- a/lib/elasticsearch/drain/autoscaling.rb
+++ b/lib/elasticsearch/drain/autoscaling.rb
@@ -19,15 +19,11 @@ module Elasticsearch
       end
 
       def asg_client
-        Aws::AutoScaling::Client.new(region: region, credentials: creds)
+        Aws::AutoScaling::Client.new(region: region)
       end
 
       def ec2_client
-        Aws::EC2::Client.new(region: region, credentials: creds)
-      end
-
-      def creds
-        Aws::SharedCredentials.new
+        Aws::EC2::Client.new(region: region)
       end
 
       def find_instances_in_asg

--- a/lib/elasticsearch/drain/cli.rb
+++ b/lib/elasticsearch/drain/cli.rb
@@ -12,9 +12,9 @@ module Elasticsearch
       option :host, default: 'localhost:9200'
       option :asg, required: true
       option :region, required: true
-      option :nodes
-      option :number
-      option :continue, type: :boolean, default: true
+      option :nodes, type: :array, desc: 'A comma separated list of node IDs to drain'
+      option :number, type: :numeric, desc: 'The number of nodes to drain'
+      option :continue, type: :boolean, default: true, desc: 'Whether to continue draining nodes once the first iteration of --number is complete'
       def asg # rubocop:disable Metrics/MethodLength
         @drainer = Elasticsearch::Drain.new(options[:host],
                                             options[:asg],
@@ -36,7 +36,7 @@ module Elasticsearch
         # If a node or nodes are specified, only drain the requested node(s)
         @active_nodes = active_nodes.find_all do |n|
           instance_id = drainer.asg.instance(n.ipaddress).instance_id
-          options[:nodes].split(',').include?(instance_id)
+          options[:nodes].include?(instance_id)
         end if options[:nodes]
 
         do_exit { say_status 'Complete', 'Nothing to do', :green } if active_nodes.empty?

--- a/lib/elasticsearch/drain/cli.rb
+++ b/lib/elasticsearch/drain/cli.rb
@@ -2,12 +2,13 @@ require 'thor'
 
 module Elasticsearch
   class Drain
-    class CLI < ::Thor
+    class CLI < ::Thor # rubocop:disable Metrics/ClassLength
       package_name :elasticsearch
 
       attr_reader :drainer
       attr_accessor :active_nodes
 
+      # rubocop:disable Metrics/LineLength
       desc 'asg', 'Drain all documents from all nodes in an EC2 AutoScaling Group'
       option :host, default: 'localhost:9200'
       option :asg, required: true
@@ -15,6 +16,7 @@ module Elasticsearch
       option :nodes, type: :array, desc: 'A comma separated list of node IDs to drain. If specified, the --number option has no effect'
       option :number, type: :numeric, desc: 'The number of nodes to drain'
       option :continue, type: :boolean, default: true, desc: 'Whether to continue draining nodes once the first iteration of --number is complete'
+      # rubocop:enable Metrics/LineLength
       def asg # rubocop:disable Metrics/MethodLength
         @drainer = Elasticsearch::Drain.new(options[:host],
                                             options[:asg],
@@ -32,7 +34,6 @@ module Elasticsearch
           number_to_drain = options[:number]
           currently_draining_nodes = drainer.cluster.currently_draining('_id')
         end
-
 
         # If a node or nodes are specified, only drain the requested node(s)
         @active_nodes = active_nodes.find_all do |n|
@@ -147,7 +148,8 @@ module Elasticsearch
           say_status(
             'Removing Node',
             "Removing #{instance.ipaddress} from Elasticsearch cluster and #{drainer.asg.asg} AutoScalingGroup",
-            :magenta)
+            :magenta
+          )
           sleep 5 unless instance.in_recovery?
           node = "#{instance.instance_id}(#{instance.ipaddress})"
           ensure_cluster_healthy

--- a/lib/elasticsearch/drain/cli.rb
+++ b/lib/elasticsearch/drain/cli.rb
@@ -12,7 +12,7 @@ module Elasticsearch
       option :host, default: 'localhost:9200'
       option :asg, required: true
       option :region, required: true
-      option :nodes, type: :array, desc: 'A comma separated list of node IDs to drain'
+      option :nodes, type: :array, desc: 'A comma separated list of node IDs to drain. If specified, the --number option has no effect'
       option :number, type: :numeric, desc: 'The number of nodes to drain'
       option :continue, type: :boolean, default: true, desc: 'Whether to continue draining nodes once the first iteration of --number is complete'
       def asg # rubocop:disable Metrics/MethodLength
@@ -25,6 +25,7 @@ module Elasticsearch
 
         # If :nodes are specified, :number has no effect
         if options[:nodes]
+          say "Nodes #{options[:nodes].join(', ')} have been specified, the --number option has no effect"
           number_to_drain = nil
           currently_draining_nodes = nil
         else

--- a/lib/elasticsearch/drain/cli.rb
+++ b/lib/elasticsearch/drain/cli.rb
@@ -124,6 +124,16 @@ module Elasticsearch
           drainer.cluster.drain_nodes(nodes_to_drain, '_id')
         end
 
+        def wait_sleep_time
+          ips = active_nodes.map(&:ipaddress)
+          bytes = drainer.nodes.filter_nodes(ips).map(&:bytes_stored)
+          sleep_time = 10
+          sleep_time = 30 if bytes.any? { |b| b >= 100_000 }
+          sleep_time = 60 if bytes.any? { |b| b >= 1_000_000 }
+          sleep_time = 120 if bytes.any? { |b| b >= 10_000_000_000 }
+          sleep_time
+        end
+
         def remove_nodes(nodes) # rubocop:disable Metrics/MethodLength
           while nodes.length > 0
             nodes.each do |instance|

--- a/lib/elasticsearch/drain/cli.rb
+++ b/lib/elasticsearch/drain/cli.rb
@@ -13,12 +13,25 @@ module Elasticsearch
       option :asg, required: true
       option :region, required: true
       option :nodes
+      option :number
+      option :continue, type: :boolean, default: true
       def asg # rubocop:disable Metrics/MethodLength
         @drainer = Elasticsearch::Drain.new(options[:host],
                                             options[:asg],
                                             options[:region])
+
         ensure_cluster_healthy
         @active_nodes = drainer.active_nodes_in_asg
+
+        # If :nodes are specified, :number has no effect
+        if options[:nodes]
+          number_to_drain = nil
+          currently_draining_nodes = nil
+        else
+          number_to_drain = options[:number]
+          currently_draining_nodes = drainer.cluster.currently_draining('_id')
+        end
+
 
         # If a node or nodes are specified, only drain the requested node(s)
         @active_nodes = active_nodes.find_all do |n|
@@ -27,10 +40,46 @@ module Elasticsearch
         end if options[:nodes]
 
         do_exit { say_status 'Complete', 'Nothing to do', :green } if active_nodes.empty?
-        say_status 'Found Nodes', "AutoScalingGroup: #{instances}", :magenta
-        ensure_cluster_healthy
-        drain_nodes
-        remove_nodes
+        say_status 'Found Nodes', "AutoScalingGroup: #{instances(active_nodes)}", :magenta
+
+        until active_nodes.empty?
+          ensure_cluster_healthy
+
+          nodes = active_nodes
+
+          # If there are nodes in cluster settings "transient.cluster.routing.allocation.exclude"
+          # test if those nodes are still in the ASG. If so, work on them first unless nodes are
+          # specified.
+          if currently_draining_nodes
+            nodes_to_drain = active_nodes.find_all { |n| currently_draining_nodes.split(',').include?(n.id) }
+
+            # If the list of nodes_to_drain isn't empty, we want to set nodes to the list of nodes
+            # we've already been working on.
+            unless nodes_to_drain.empty?
+              nodes = nodes_to_drain
+
+              say_status 'Active Nodes', "Resuming drain process on #{instances(nodes)}", :magenta
+            end
+
+            # We should only process currently_draining_nodes once
+            currently_draining_nodes = nil
+          end
+
+          # If we specify a number but DON'T specify nodes, sample the active_nodes.
+          if number_to_drain
+            nodes = nodes.sample(number_to_drain.to_i)
+            say_status 'Active Nodes', "Sampled #{number_to_drain} nodes and got #{instances(nodes)}", :magenta
+          end
+
+          @active_nodes = nodes unless options[:continue]
+
+          drain_nodes(nodes)
+          remove_nodes(nodes)
+
+          # Remove the drained nodes from the list of active_nodes
+          @active_nodes -= nodes
+          say_status 'Drain Nodes', "#{active_nodes.length} nodes remaining", :green unless active_nodes.empty?
+        end
         say_status 'Complete', 'Draining nodes complete!', :green
       end
 
@@ -48,42 +97,42 @@ module Elasticsearch
           exit code
         end
 
-        def instances
-          instances = active_nodes.map(&:ipaddress)
+        def instances(nodes)
+          instances = nodes.map(&:ipaddress)
           instances.join(' ')
         end
 
-        def adjusted_min_size
+        def adjusted_min_size(nodes)
           min_size = drainer.asg.min_size
           desired_capacity = drainer.asg.desired_capacity
-          if (desired_capacity - active_nodes.length) >= min_size # Removing the active_nodes won't violate the min_size
-            # Reduce the asg min_size proportionally
-            desired_min_size = (min_size - active_nodes.length) <= 0 ? 0 : (min_size - active_nodes.length)
-          else
-            # Removing the active_nodes will result in the min_size being violated
-            desired_min_size = desired_capacity - active_nodes.length
-          end
+          desired_min_size = if (desired_capacity - nodes.length) >= min_size # Removing the nodes won't violate the min_size
+                               # Reduce the asg min_size proportionally
+                               (min_size - nodes.length) <= 0 ? 0 : (min_size - nodes.length)
+                             else
+                               # Removing the nodes will result in the min_size being violated
+                               desired_capacity - nodes.length
+                             end
           desired_min_size
         end
 
-        def drain_nodes
-          drainer.asg.min_size = adjusted_min_size
-          nodes_to_drain = active_nodes.map(&:id).join(',')
+        def drain_nodes(nodes)
+          drainer.asg.min_size = adjusted_min_size(nodes)
+          nodes_to_drain = nodes.map(&:id).join(',')
           say_status 'Drain Nodes', "Draining nodes: #{nodes_to_drain}", :magenta
           drainer.cluster.drain_nodes(nodes_to_drain, '_id')
         end
 
-        def remove_nodes # rubocop:disable Metrics/MethodLength
-          while active_nodes.length > 0
-            active_nodes.each do |instance|
+        def remove_nodes(nodes) # rubocop:disable Metrics/MethodLength
+          while nodes.length > 0
+            nodes.each do |instance|
               instance = drainer.nodes.filter_nodes([instance.ipaddress], true).first
               if instance.bytes_stored > 0
                 say_status 'Drain Status', "Node #{instance.ipaddress} has #{instance.bytes_stored} bytes to move", :blue
                 sleep 2
               else
                 next unless remove_node(instance)
-                active_nodes.delete_if { |n| n.ipaddress == instance.ipaddress }
-                break if active_nodes.length < 1
+                nodes.delete_if { |n| n.ipaddress == instance.ipaddress }
+                break if nodes.length < 1
                 say_status 'Waiting', 'Sleeping for 1 minute before removing the next node', :green
                 sleep 60
               end

--- a/lib/elasticsearch/drain/cluster.rb
+++ b/lib/elasticsearch/drain/cluster.rb
@@ -34,6 +34,11 @@ module Elasticsearch
           }
         )
       end
+
+      def currently_draining(exclude_by = '_ip')
+        settings = cluster.get_settings(:flat_settings => true)
+        settings.fetch('transient', {}).fetch("cluster.routing.allocation.exclude.#{exclude_by}", nil)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds a feature to drain _N_ nodes from a cluster at a time. Nodes are sampled randomly then set to drain. If the Ruby process is interrupted locally and then started again, the drain script will determine which nodes are currently draining and continue draining them until they are complete.