### PR TITLE
Increase EC2 instance terminate wait time

### DIFF
--- a/lib/elasticsearch/drain/node.rb
+++ b/lib/elasticsearch/drain/node.rb
@@ -99,7 +99,7 @@ module Elasticsearch
         @asg.ec2_client.wait_until(:instance_terminated,
                                    instance_ids: [instance_id]) do |w|
           w.max_attempts = 10
-          w.delay = 30
+          w.delay = 60
         end
       end
     end


### PR DESCRIPTION
This changes the maximum `wait_time` for an instance to become
terminated from 5 minutes to 10 minutes.