### PR TITLE
TMP change: the drain tool sometimes fails because the adjusted_min_s…

### DIFF
--- a/lib/elasticsearch/drain/cli.rb
+++ b/lib/elasticsearch/drain/cli.rb
@@ -121,6 +121,7 @@ module Elasticsearch
                                # Removing the nodes will result in the min_size being violated
                                desired_capacity - nodes.length
                              end
+          say_status 'Debug', 'min_size = #{min_size}, desired_capacity = #{desired_capacity}, desired_min_size = #{desired_min_size}', :magenta
           desired_min_size
         end
 


### PR DESCRIPTION
…ize method returns a negative value. I added print statements to rerun the test and see what's the issue

There seems to be a bug where the adjusted_min_size method returns a negative value. When this happens, the drain tool exits with status code 1. I added a print statement so I can recreate the test and see how it gets a negative value and fix the bug.