### PR TITLE
prevents drain from failing when object is empty

### DIFF
--- a/lib/elasticsearch/drain/node.rb
+++ b/lib/elasticsearch/drain/node.rb
@@ -97,7 +97,10 @@ module Elasticsearch
       end
 
       def in_recovery?
-        recovery = client.cat.recovery(format: 'json', v: true).first.values
+        recovery = client.cat.recovery(format: 'json', v: true)
+        if recovery.first != nil
+          recovery = recovery.first.values
+        end
         [hostname, name].any? { |a| recovery.include?(a) }
       end
 


### PR DESCRIPTION
## Description
This is a fix for a failed drain on an ASG because it was throwing an error during the in-recovery? method when there are no values present. For more information about this elasticsearch cat API called here - [cat recovery](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/cat-recovery.html ). 

## Testing
To test this locally.. 
1. added a test ASG with one instance to escqendpointforensicsmaster
2. made sure the cluster was healthy
3. cd elasticsearch-drain/bin and run command ``` ruby drain asg --asg=TEST_ASG_NAME --region=REGION ```